### PR TITLE
Closes #109

### DIFF
--- a/frontend/css/decat.css
+++ b/frontend/css/decat.css
@@ -364,6 +364,10 @@ html, body, #container, .fill {
     content: 'P';
     font-size: x-large;
 }
+.map-icon.archived:after{
+    content: 'A';
+    font-size: x-large;
+}
 
 .d-hazard .event-check:hover {
     color: #777;

--- a/frontend/js/components/EventEditor.jsx
+++ b/frontend/js/components/EventEditor.jsx
@@ -30,7 +30,7 @@ const LocationFilter = require('../components/LocationFilter');
 class EventEditor extends React.Component {
     static propTypes = {
         className: PropTypes.string,
-        mode: PropTypes.string,
+        mode: PropTypes.oneOf(["ADD", "LIST"]),
         height: PropTypes.number,
         currentEvent: PropTypes.object,
         hazards: PropTypes.array,
@@ -346,6 +346,7 @@ class EventEditor extends React.Component {
                             <Button bsSize="sm" onClick={this.props.onClose}><Message msgId="eventeditor.cancel"/></Button>
                             <Button disabled={this.props.status.saving} bsSize="sm" onClick={this.save}><Message msgId="eventeditor.save"/></Button>
                             {this.props.mode === 'ADD' ? null : <Button disabled={this.props.status.saving} bsSize="sm" onClick={this.promote}><Message msgId="eventeditor.promote"/></Button>}
+                            {this.props.mode === 'ADD' ? null : <Button disabled={this.props.status.saving} bsSize="sm" onClick={this.archive}><Message msgId="eventeditor.archive"/></Button>}
                         </ButtonGroup>
                     </Col>
                 </Row>
@@ -355,11 +356,13 @@ class EventEditor extends React.Component {
     }
 
     promote = () => {
-        this.props.onSave(this.props.mode, true);
+        this.props.onSave("PROMOTE", true);
     };
-
+    archive = () => {
+        this.props.onSave("ARCHIVE", false, true);
+    };
     save = () => {
-        this.props.onSave(this.props.mode, false);
+        this.props.onSave(this.props.mode === 'LIST' && 'UPDATE' || this.props.mode, false);
     };
 
     changeName = (e) => {

--- a/frontend/js/components/Events.jsx
+++ b/frontend/js/components/Events.jsx
@@ -29,7 +29,7 @@ class Events extends React.Component {
         onAddEvent: PropTypes.func,
         isAuthorized: PropTypes.func,
         onToggleVisibility: PropTypes.func,
-        onPromote: PropTypes.func,
+        onEditEvent: PropTypes.func,
         searchInput: PropTypes.string,
         serchedText: PropTypes.string,
         onSearchTextChange: PropTypes.func,
@@ -138,7 +138,7 @@ class Events extends React.Component {
         );
     }
     promote = (event) => {
-        this.props.onPromote(event);
+        this.props.onEditEvent(event);
     };
 
     toggleVisibility = (event) => {

--- a/frontend/js/epics/GeoNodeConfig.js
+++ b/frontend/js/epics/GeoNodeConfig.js
@@ -135,7 +135,7 @@ module.exports = {
             const {map} = store.getState() || {};
             const promotedLayer = head(eventOperatorLayers.filter(l => l.id === 'promoted_alerts'));
             const minZoom = ConfigUtils.getConfigProp("promotedLayerMinZoom");
-            const newAction = map.present.zoom < minZoom && removeLayer('promoted_alerts') || addLayer(promotedLayer);
+            const newAction = map.present.zoom < minZoom && removeLayer('promoted_alerts') || addLayer(promotedLayer, false);
             return Rx.Observable.of(newAction);
         })
 };

--- a/frontend/js/ms2override/decatDefaultLayers.js
+++ b/frontend/js/ms2override/decatDefaultLayers.js
@@ -6,6 +6,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 module.exports = [
+    {
+        "type": "vector",
+        "id": "archived_alerts",
+        "name": "archived_alerts",
+        "title": "Archived",
+        "group": "Alerts",
+        "visibility": true,
+        "styleName": "marker",
+        "hideLoading": true,
+        "style": {
+            "html": {
+               "className": "fa fa-3x icon-eq d-text-warning",
+               "iconSize": [36, 36],
+               "iconAnchor": [18, 18]
+            }
+        }
+    },
    {
             "type": "vector",
             "name": "editalert",
@@ -74,5 +91,4 @@ module.exports = [
             }
         }
     }
-
 ];

--- a/frontend/js/plugins/EarlyWarning.jsx
+++ b/frontend/js/plugins/EarlyWarning.jsx
@@ -16,7 +16,7 @@ const LocaleUtils = require('../../MapStore2/web/client/utils/LocaleUtils');
 
 const {loadRegions, selectRegions, addEvent, changeEventProperty, toggleDraw, cancelEdit, toggleEntityValue, onSearchTextChange, resetAlertsTextSearch, toggleEntities,
     loadEvents, saveEvent, toggleEventVisibility,
-    promoteEvent} = require('../actions/alerts');
+    editEvent} = require('../actions/alerts');
 const {changeInterval} = require('../actions/alerts');
 const {isAuthorized} = require('../utils/SecurityUtils');
 const {connect} = require('react-redux');
@@ -66,7 +66,7 @@ const Events = connect((state) => ({
 }), {
     onAddEvent: addEvent,
     onToggleVisibility: toggleEventVisibility,
-    onPromote: promoteEvent,
+    onEditEvent: editEvent,
     onSearchTextChange,
     resetAlertsTextSearch,
     loadEvents

--- a/frontend/js/reducers/alerts.js
+++ b/frontend/js/reducers/alerts.js
@@ -7,7 +7,7 @@
  */
 
 const {DATA_LOADED, DATA_LOAD_ERROR, REGIONS_LOADED, REGIONS_LOAD_ERROR, EVENTS_LOADED, EVENTS_LOAD_ERROR, REGIONS_LOADING, SELECT_REGIONS, RESET_REGIONS_SELECTION, TOGGLE_ENTITY_VALUE, ADD_EVENT, CHANGE_EVENT_PROPERTY, TOGGLE_DRAW, CANCEL_EDIT, SEARCH_TEXT_CHANGE, RESET_ALERTS_TEXT_SEARCH, CHANGE_INTERVAL,
-TOGGLE_ENTITIES, EVENT_SAVED, EVENT_PROMOTED, EVENT_SAVE_ERROR, EVENT_SAVING, TOGGLE_EVENT, PROMOTE_EVENT, EVENTS_LOADING, PROMOTED_EVENTS_LOADED} = require('../actions/alerts');
+TOGGLE_ENTITIES, EVENT_CREATED, EVENT_PROMOTED, EVENT_SAVE_ERROR, EVENT_SAVING, TOGGLE_EVENT, EDIT_EVENT, EVENTS_LOADING, PROMOTED_EVENTS_LOADED, ARCHIVED_EVENTS_LOADED, EVENT_UPDATED, EVENT_ARCHIVED} = require('../actions/alerts');
 const {GEONODE_MAP_CONFIG_LOADED, GEONODE_MAP_UPDATED, SAVE_MAP_ERROR, UPDATING_GEONODE_MAP} = require('../actions/GeoNodeConfig');
 
 
@@ -68,8 +68,22 @@ function alerts(state = null, action) {
             promotedEventsInfo: {
                page: action.page || 0,
                total: action.total || 0,
-               pageSize: action.pageSize || 10,
-               queryTime: action.queryTime,
+               pageSize: action.pageSize || 1000,
+               filter: action.filter
+            }
+        });
+    }
+    case ARCHIVED_EVENTS_LOADED: {
+        return assign({}, state, {
+            archivedEvents: action.events.map((ev) => assign({}, ev, {
+                geometry: assign({}, ev.geometry, {
+                    coordinates: [ev.geometry.coordinates[1], ev.geometry.coordinates[0]]
+                })
+            })),
+            archivedEventsInfo: {
+               page: action.page || 0,
+               total: action.total || 0,
+               pageSize: action.pageSize || 1000,
                filter: action.filter
             }
         });
@@ -97,10 +111,10 @@ function alerts(state = null, action) {
             regions: {},
             drawEnabled: true
         });
-    case PROMOTE_EVENT:
+    case EDIT_EVENT:
         return assign({}, state,
         {
-            mode: 'PROMOTE',
+            mode: 'EDIT',
             currentEvent: AlertsUtils.getEvent(state, action.event),
             regionsLoading: false,
             regions: {},
@@ -132,12 +146,10 @@ function alerts(state = null, action) {
         return assign({}, state, {
             saving: action.status
         });
-    case EVENT_SAVED:
-        return assign({}, state, {
-            saving: false,
-            saveError: null
-        });
+    case EVENT_CREATED:
     case EVENT_PROMOTED:
+    case EVENT_UPDATED:
+    case EVENT_ARCHIVED:
         return assign({}, state, {
             saving: false,
             saveError: null

--- a/frontend/js/utils/AlertsUtils.js
+++ b/frontend/js/utils/AlertsUtils.js
@@ -55,8 +55,8 @@ module.exports = {
             updated: event.properties.updated_at
         };
     },
-    createFilter: (hazards, levels, regions, interval, text, promoted = false) => {
-        let filter = `&promoted=${promoted}&hazard_type__in=${getHazards(hazards)}&level__in=${getLevels(levels)}`;
+    createFilter: (hazards, levels, regions, interval, text, promoted = false, archived = false) => {
+        let filter = `&promoted=${promoted}&archived=${archived}&hazard_type__in=${getHazards(hazards)}&level__in=${getLevels(levels)}`;
         if (regions && regions.length > 0) {
             filter += `&regions__code__in=${getRegionsCode(regions)}`;
         }

--- a/frontend/static/decat/translations/data.en-US
+++ b/frontend/static/decat/translations/data.en-US
@@ -23,6 +23,7 @@
             "createalert": "Create Alert",
             "promotealert": "Promote Alert",
             "promote": "Promote",
+            "archive": "Archive",
             "alertinfo": "Alert info",
             "nameholder": "Enter title...",
             "hazardholder": "Hazard type...",

--- a/frontend/static/decat/translations/data.it-IT
+++ b/frontend/static/decat/translations/data.it-IT
@@ -23,6 +23,7 @@
             "createalert": "Crea nuovo alert",
             "promotealert": "Approva un alert",
             "promote": "Approva",
+            "archive": "Archivia",
             "alertinfo": "Informazioni",
             "nameholder": "Titolo...",
             "hazardholder": "Tipo di incidente...",


### PR DESCRIPTION
Refactored events action to  
ADD_EVENT open panel to create a new event 
EDIT_EVENT open panel to edit existing event
EVENT_CREATED when new event is saved
EVENT_UPDATED when existing event is modified
EVENT_PROMOTED event is promoted
EVENT_ARCHIVED  event is archived.
This allows to correctly reload events, promotedEvents and archived lists.
This pull add archive btn and relative action to move an alerts in archived alerts.
Also add archivedEvents layers that shows archived alerts.
Improved loading of archived alerts and promoted alerts, these are now refreshed only when strictly necessary.