### PR TITLE
Fixes #229 Annotations load / save for EM

### DIFF
--- a/frontend/js/actions/emergencymanager.js
+++ b/frontend/js/actions/emergencymanager.js
@@ -51,9 +51,10 @@ function checkCopValidity(mapId, hazardId) {
     };
 }
 
-function invalidCop() {
+function invalidCop(id) {
     return {
-        type: INVALID_COP
+        type: INVALID_COP,
+        id
     };
 }
 

--- a/frontend/js/components/EditCop.jsx
+++ b/frontend/js/components/EditCop.jsx
@@ -7,15 +7,15 @@
  */
 const React = require('react');
 
-const { Button} = require('react-bootstrap');
-
+const {Grid, Row, Col, Panel, Button} = require('react-bootstrap');
+const LocaleUtils = require('../../MapStore2/web/client/utils/LocaleUtils');
 const PropTypes = require('prop-types');
 // const AlertsUtils = require('../utils/AlertsUtils');
 const Message = require('../../MapStore2/web/client/components/I18N/Message');
 const ConfirmDialog = require('../../MapStore2/web/client/components/misc/ConfirmDialog');
 const Portal = require('../../MapStore2/web/client/components/misc/Portal');
 const AlertsUtils = require('../utils/AlertsUtils');
-
+const moment = require('moment');
 
 class EditCop extends React.Component {
     static propTypes = {
@@ -27,7 +27,8 @@ class EditCop extends React.Component {
           pageSize: PropTypes.number,
           assessments: PropTypes.array,
           cancelAddAssessment: PropTypes.func,
-          accordionHeight: PropTypes.number
+          accordionHeight: PropTypes.number,
+          toggleAnnotations: PropTypes.func
       };
 
       static contextTypes = {
@@ -38,7 +39,8 @@ class EditCop extends React.Component {
           onSave: () => {},
           cancelAddAssessment: () => {},
           currentHazard: {},
-          height: 400
+          height: 400,
+          toggleAnnotations: () => {}
       };
     state = {
         showConfirm: false
@@ -46,11 +48,90 @@ class EditCop extends React.Component {
     getHazard = (type) => {
         return AlertsUtils.getHazardIcon(this.props.hazards, type);
     }
+    getPoint = () => {
+        const {coordinates: point} = this.props.currentHazard && this.props.currentHazard.geometry;
+        if (point) {
+            let latDFormat = {style: "decimal", minimumIntegerDigits: 1, maximumFractionDigits: 6, minimumFractionDigits: 6};
+            let lngDFormat = {style: "decimal", minimumIntegerDigits: 1, maximumFractionDigits: 6, minimumFractionDigits: 6};
+
+            return new Intl.NumberFormat(undefined, latDFormat).format(Math.abs(point[1])) + '°' + (Math.sign(point[1]) >= 0 ? 'N' : 'S') + ' ' +
+                new Intl.NumberFormat(undefined, lngDFormat).format(Math.abs(point[0])) + '°' + (Math.sign(
+                    point[0]) >= 0 ? 'E' : 'W');
+        }
+        return '';
+    }
+    renderHeader = () => {
+        const {hazard_type, level, title} = this.props && this.props.currentHazard && this.props.currentHazard.properties || {};
+        return (
+            <Grid fluid>
+                <Row style={{height: 56}}>
+                    <Col xs={2} className="text-center">
+                        <h5 className={`fa icon-${this.getHazard(hazard_type)} d-text-${level} fa-2x`}></h5>
+                    </Col>
+                    <Col xs={8} className="text-center" >
+                    <h4>{title}</h4>
+                    </Col>
+                    <Col xs={1}/>
+                </Row>
+            </Grid>
+            );
+    }
+    renderBody = () => {
+        const { level, updated_at, reported_at, source, description} = this.props && this.props.currentHazard && this.props.currentHazard.properties || {};
+        return (
+            <Grid fluid>
+                <div style={{overflow: 'auto', height: this.props.height - (30 + 40 + 60 + 132 )}}>
+                    <Row className="hazard-info">
+                        <Panel header={LocaleUtils.getMessageById(this.context.messages, "decatassessment.hazardinfo")} eventKey="1" collapsible>
+                            <Row className="text-center">
+                                <Col xs={12} className={`d-text-${level}`}>{level}</Col>
+                            </Row>
+                            <Row>
+                                <Col xs={12}>
+                                    <span className="hazard-info-label"><Message msgId="eventeditor.from"/></span>
+                                    {source && source.name}
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col xs={12}>
+                                    <span className="hazard-info-label"><Message msgId="eventeditor.updatedtime"/></span>
+                                    {moment(updated_at).format('YYYY-MM-DD hh:mm:ss A')}
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col xs={12}>
+                                    <span className="hazard-info-label"><Message msgId="eventeditor.reportedtime"/></span>
+                                    {moment(reported_at).format('YYYY-MM-DD hh:mm:ss A')}
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col xs={12} ><span className="hazard-info-label"><Message msgId="eventeditor.location"/></span>{this.getPoint()}</Col>
+                            </Row>
+                            <Row>
+                                <Col xs={12} ><span className="hazard-info-label"><Message msgId="eventeditor.description"/></span>
+                                    <Row className="hazard-info-description"><Col xs={12}>{description}</Col></Row>
+                                </Col>
+                            </Row>
+
+                        </Panel>
+                    </Row>
+                    <Row>
+                        <Col xs={12} className="text-center">
+                            <Button onClick={() => { this.props.toggleAnnotations(); }} bsSize="sm">Annotations</Button>
+                        </Col>
+                    </Row>
+                </div>
+            </Grid>
+            );
+    }
     render() {
         const {height} = this.props;
         return (
-            <div id="decat-impact-assessment" key="decat-impact-assessment" className="decat-accordion" style={{height: height - 20}} >
-                TODO:: EDIT COP ANNOTATIONS
+            <div id="decat-impact-assessment" key="decat-impact-assessment" style={{height: height - 20}} >
+                <div className="hazard-container" style={{overflow: 'auto', height: height - 30}}>
+                {this.renderHeader()}
+                {this.renderBody()}
+                </div>
                 <div style={{ paddingTop: 20, paddingBottom: 20, backgroundColor: 'white', position: 'absolute', top: height - 80, width: "100%"}}>
                     <div className="text-center">
                         <Button bsSize="sm" onClick={this.handleCancel}><Message msgId="eventeditor.cancel"/></Button>

--- a/frontend/js/components/EditCop.jsx
+++ b/frontend/js/components/EditCop.jsx
@@ -82,7 +82,7 @@ class EditCop extends React.Component {
             <Grid fluid>
                 <div style={{overflow: 'auto', height: this.props.height - (30 + 40 + 60 + 132 )}}>
                     <Row className="hazard-info">
-                        <Panel header={LocaleUtils.getMessageById(this.context.messages, "decatassessment.hazardinfo")} eventKey="1" collapsible>
+                        <Panel header={LocaleUtils.getMessageById(this.context.messages, "decatassessment.hazardinfo")} eventKey="1" collapsible expanded>
                             <Row className="text-center">
                                 <Col xs={12} className={`d-text-${level}`}>{level}</Col>
                             </Row>

--- a/frontend/js/epics/GeoNodeConfig.js
+++ b/frontend/js/epics/GeoNodeConfig.js
@@ -53,8 +53,19 @@ module.exports = {
         action$.ofType(CREATE_GEONODE_MAP).
             switchMap((action) => {
                 const {map, layers, alerts, impactassessment = {}} = store.getState() || {};
+                /* remove external annotations */
+                const newLayers = assign({}, layers);
+                const newFlat = newLayers.flat.map(layer => {
+                    if (layer.id === 'annotation') {
+                        let newLayer = assign({}, layer);
+                        newLayer.features = newLayer.features.filter(feature => !feature.match(/external_/));
+                        return assign({}, newLayer);
+                    }
+                    return assign({}, layer);
+                });
+
                 const {documents = []} = impactassessment;
-                const config = GeoNodeMapUtils.getGeoNodeMapConfig( map.present, layers.flat, alerts.geonodeMapConfig, documents, action.about, 0);
+                const config = GeoNodeMapUtils.getGeoNodeMapConfig( map.present, newFlat, alerts.geonodeMapConfig, documents, action.about, 0);
                 return Rx.Observable.fromPromise(
                                 axios.post("/maps/new/data", config).then(response => response.data)
                             ).map((res) => {

--- a/frontend/js/epics/emergencyManager.js
+++ b/frontend/js/epics/emergencyManager.js
@@ -1,0 +1,96 @@
+/**
+* Copyright 2017, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+const Rx = require('rxjs');
+const axios = require('../../MapStore2/web/client/libs/ajax');
+const {annotationsLayerSelector} = require('../../MapStore2/web/client/selectors/annotations');
+const {updateNode} = require('../../MapStore2/web/client/actions/layers');
+// const {TOGGLE_CONTROL} = require('../../MapStore2/web/client/actions/controls');
+const {EDIT_COP} = require('../actions/emergencymanager');
+const {MAP_CONFIG_LOADED} = require('../../MapStore2/web/client/actions/config');
+const {SAVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION} = require('../../MapStore2/web/client/actions/annotations');
+const assign = require('object-assign');
+const {ADD_ASSESSMENT} = require('../actions/impactassessment');
+const hazardIdSelector = state => state && state.impactassessment && state.impactassessment.currentHazard && state.impactassessment.currentHazard.id;
+const currentRoleSelector = state => state && state.security && state.security.currentRole;
+
+module.exports = {
+    getExternalAnnotations: (action$, store) => action$.ofType(EDIT_COP, ADD_ASSESSMENT)
+        .switchMap(() =>
+            action$.ofType(MAP_CONFIG_LOADED)
+                .switchMap(() => {
+                    const hazardId = hazardIdSelector(store.getState());
+                    const currentRole = currentRoleSelector(store.getState());
+                    return Rx.Observable.fromPromise(axios.get(`/decat/api/alerts/${hazardId}/annotations/?format=json`).then(response => response.data))
+                        .switchMap(data => {
+                            const dataFeatures = data.features;
+                            const annotations = annotationsLayerSelector(store.getState());
+                            if (!annotations || !dataFeatures) {
+                                return Rx.Observable.empty();
+                            }
+                            const copFeatures = annotations.features ? [...annotations.features.map(f => assign({}, f, {readOnly: currentRole === 'emergency-manager'}))] : [];
+                            const externalFeatures = dataFeatures.map(f => {
+                                const style = f.properties && f.properties.style ? assign({}, f.properties.style) : {iconColor: "blue", iconGlyph: "comment", iconShape: "square"};
+                                return assign({}, f, { style, properties: assign({}, f.properties, {id: 'external_' + f.id})});
+                            });
+
+                            const features = [...copFeatures, ...externalFeatures];
+                            return Rx.Observable.of(updateNode("annotations", "layers", {features}));
+
+                        })
+                        .catch((/*error*/) => Rx.Observable.empty());
+                })),
+    saveExternalAnnotations: (action$, store) =>
+        action$.ofType(SAVE_ANNOTATION)
+            .filter(action => action.newFeature && currentRoleSelector(store.getState()) === 'emergency-manager')
+            .switchMap((action) => {
+                const hazardId = hazardIdSelector(store.getState());
+                const styleKeys = Object.keys(action.style).filter(key => key !== 'highlight');
+                const style = styleKeys.reduce((a, b) => assign({}, a, {[b]: action.style[b]}), {});
+                const properties = assign({}, action.fields, {hazard: hazardId}, {style: JSON.stringify(style)});
+                const geometry = assign({}, action.geometry);
+                return Rx.Observable.fromPromise(axios.post(`/decat/api/alerts/${hazardId}/annotations/`, {geometry, properties}).then(response => response.data)).switchMap((res) => {
+                    const annotations = annotationsLayerSelector(store.getState());
+                    const features = annotations && annotations.features.map(annotation => {
+                        if (annotation.properties && annotation.properties.id === action.id) {
+                            const prprts = assign({}, annotation.properties, {id: 'external_' + res.id});
+                            return assign({}, annotation, {properties: prprts});
+                        }
+                        return assign({}, annotation);
+                    }) || null;
+                    return !features ? Rx.Observable.empty() : Rx.Observable.of(updateNode("annotations", "layers", {features}));
+                })
+                .catch(() => Rx.Observable.empty());
+            }),
+    deleteExternalAnnotations: (action$, store) =>
+        action$.ofType(CONFIRM_REMOVE_ANNOTATION)
+            .filter(action => action.id && action.id.match(/external_/))
+            .switchMap((action) => {
+                const id = action.id.replace(/external_/, '');
+                const hazardId = hazardIdSelector(store.getState());
+                return Rx.Observable.fromPromise(axios.delete(`/decat/api/alerts/${hazardId}/annotations/${id}/`).then(response => response.data)).switchMap(() => {
+                    return Rx.Observable.empty();
+                })
+                .catch(() => Rx.Observable.empty());
+            }),
+    editExternalAnnotations: (action$, store) =>
+        action$.ofType(SAVE_ANNOTATION)
+            .filter(action => !action.newFeature && action.id && action.id.match(/external_/))
+            .switchMap((action) => {
+                const id = action.id.replace(/external_/, '');
+                const hazardId = hazardIdSelector(store.getState());
+                const styleKeys = Object.keys(action.style).filter(key => key !== 'highlight');
+                const style = styleKeys.reduce((a, b) => assign({}, a, {[b]: action.style[b]}), {});
+                const properties = assign({}, action.fields, {hazard: hazardId}, {style: JSON.stringify(style)});
+                const geometry = assign({}, action.geometry);
+                return Rx.Observable.fromPromise(axios.patch(`/decat/api/alerts/${hazardId}/annotations/${id}/`, {geometry, properties}).then(response => response.data)).switchMap(() => {
+
+                    return Rx.Observable.empty();
+                })
+                .catch(() => Rx.Observable.empty());
+            })
+};

--- a/frontend/js/epics/emergencyManager.js
+++ b/frontend/js/epics/emergencyManager.js
@@ -10,27 +10,53 @@ const axios = require('../../MapStore2/web/client/libs/ajax');
 const {annotationsLayerSelector} = require('../../MapStore2/web/client/selectors/annotations');
 const {show} = require('../../MapStore2/web/client/actions/notifications');
 const {updateNode} = require('../../MapStore2/web/client/actions/layers');
+const {setControlProperty} = require('../../MapStore2/web/client/actions/controls');
 const {EDIT_COP} = require('../actions/emergencymanager');
 const {MAP_CONFIG_LOADED} = require('../../MapStore2/web/client/actions/config');
-const {SAVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION, CANCEL_ADD_ASSESSMENT, saveAnnotation} = require('../../MapStore2/web/client/actions/annotations');
+const {SAVE_ANNOTATION, CONFIRM_REMOVE_ANNOTATION, saveAnnotation} = require('../../MapStore2/web/client/actions/annotations');
+const {addLayer} = require('../../MapStore2/web/client/actions/layers');
+
 const assign = require('object-assign');
 const {ADD_ASSESSMENT} = require('../actions/impactassessment');
 const hazardIdSelector = state => state && state.impactassessment && state.impactassessment.currentHazard && state.impactassessment.currentHazard.id;
 const currentRoleSelector = state => state && state.security && state.security.currentRole;
 
-const getExternals = (store) => {
+const annotationsStyle = {
+    iconGlyph: 'comment',
+    iconShape: 'square',
+    iconColor: 'blue'
+};
+
+const annotationRefreshTimeSelector = state => state && state.impactassessment && state.impactassessment.annotationRefreshTime || 5000;
+
+const getExternals = (store, viewer) => {
     const hazardId = hazardIdSelector(store.getState());
     const currentRole = currentRoleSelector(store.getState());
     return Rx.Observable.fromPromise(axios.get(`/decat/api/alerts/${hazardId}/annotations/?format=json`).then(response => response.data))
         .switchMap(data => {
-            const dataFeatures = data.features;
+            const dataFeatures = data.features || [];
             const annotations = annotationsLayerSelector(store.getState());
-            if (!annotations || !dataFeatures) {
-                return Rx.Observable.empty();
+
+            if (!annotations) {
+                const externalFeatures = dataFeatures.map(f => {
+                    const style = f.properties && f.properties.style ? assign({}, f.properties.style) : annotationsStyle;
+                    return assign({}, f, { style, properties: assign({}, f.properties, {id: 'external_' + f.id})});
+                });
+                return Rx.Observable.of(addLayer({
+                    type: 'vector',
+                    visibility: true,
+                    id: 'annotations',
+                    name: "Annotations",
+                    rowViewer: viewer,
+                    hideLoading: true,
+                    style: annotationsStyle,
+                    features: externalFeatures,
+                    handleClickOnLayer: true
+                }));
             }
             const copFeatures = annotations.features ? [...annotations.features.filter(f => !f.properties.id.match(/external_/)).map(f => assign({}, f, {readOnly: currentRole === 'emergency-manager'}))] : [];
             const externalFeatures = dataFeatures.map(f => {
-                const style = f.properties && f.properties.style ? assign({}, f.properties.style) : {iconColor: "blue", iconGlyph: "comment", iconShape: "square"};
+                const style = f.properties && f.properties.style ? assign({}, f.properties.style) : annotationsStyle;
                 return assign({}, f, { style, properties: assign({}, f.properties, {id: 'external_' + f.id})});
             });
 
@@ -47,14 +73,16 @@ const getExternals = (store) => {
         }, 'error')); });
 };
 
-module.exports = {
+module.exports = (viewer) => ({
+    openAnnotationOnStart: action$ => action$.ofType(EDIT_COP)
+        .switchMap(() => Rx.Observable.of(setControlProperty('annotations', 'enabled', true))),
     getExternalAnnotations: (action$, store) => action$.ofType(EDIT_COP, ADD_ASSESSMENT)
         .switchMap(() =>
             action$.ofType(MAP_CONFIG_LOADED)
                 .take(1)
-                .switchMap(() => Rx.Observable.timer(0, 5000)
-                    .switchMap(() => getExternals(store))
-                    .takeUntil(action$.ofType(CANCEL_ADD_ASSESSMENT))
+                .switchMap(() => Rx.Observable.timer(0, annotationRefreshTimeSelector(store.getState()))
+                    .switchMap(() => getExternals(store, viewer))
+                    .takeUntil(action$.ofType("RESTORE_DECAT"))
                 )),
     saveExternalAnnotations: (action$, store) =>
         action$.ofType(SAVE_ANNOTATION)
@@ -160,4 +188,4 @@ module.exports = {
                     position: "tr"
                 }, 'error')); });
             })
-};
+});

--- a/frontend/js/epics/impactassessment.js
+++ b/frontend/js/epics/impactassessment.js
@@ -116,8 +116,18 @@ module.exports = {
         action$.ofType(SAVE_ASSESSMENT).
         switchMap((action) => {
             const {map, layers, alerts, impactassessment = {}} = store.getState() || {};
+            /* remove external annotations */
+            const newLayers = assign({}, layers);
+            const newFlat = newLayers.flat.map(layer => {
+                if (layer.id === 'annotation') {
+                    let newLayer = assign({}, layer);
+                    newLayer.features = newLayer.features.filter(feature => !feature.match(/external_/));
+                    return assign({}, newLayer);
+                }
+                return assign({}, layer);
+            });
             const {documents = []} = impactassessment;
-            const config = GeoNodeMapUtils.getGeoNodeMapConfig( map.present, layers.flat, alerts.geonodeMapConfig, documents, action.about, 0);
+            const config = GeoNodeMapUtils.getGeoNodeMapConfig( map.present, newFlat, alerts.geonodeMapConfig, documents, action.about, 0);
             return Rx.Observable.fromPromise(
                             axios.post("/maps/new/data", config).then(response => response.data)
                         ).switchMap((res) => {

--- a/frontend/js/plugins.js
+++ b/frontend/js/plugins.js
@@ -11,7 +11,7 @@ module.exports = {
         MousePositionPlugin: require('../MapStore2/web/client/plugins/MousePosition'),
         EarlyWarningPlugin: require('./plugins/EarlyWarning'),
         ImpactAssesmentPlugin: require('./plugins/ImpactAssessment'),
-       // EmergencyManagerPlugin: require('./plugins/EmergencyManager'),
+        EmergencyManagerPlugin: require('./plugins/EmergencyManager'),
         PrintPlugin: require('../MapStore2/web/client/plugins/Print'),
         IdentifyPlugin: require('../MapStore2/web/client/plugins/Identify'),
         BackgroundSwitcherPlugin: require('../MapStore2/web/client/plugins/BackgroundSwitcher'),

--- a/frontend/js/plugins/Annotations.jsx
+++ b/frontend/js/plugins/Annotations.jsx
@@ -7,11 +7,17 @@
  */
 const assign = require('object-assign');
 const {AnnotationsPlugin, epics, reducers} = require('../../MapStore2/web/client/plugins/Annotations');
+
+const {getExternalAnnotations, saveExternalAnnotations, deleteExternalAnnotations, editExternalAnnotations} = require('../epics/emergencyManager');
 const BurgerMenu = assign(AnnotationsPlugin.BurgerMenu, {
             selector: (state) => {
                 // For the moment annotations are available only for an impact-assessor editng an assessment
                 const {security, impactassessment} = state;
                 const {currentRole} = security || {};
+
+                if (currentRole === "emergency-manager" && impactassessment && impactassessment.mode === 'EDIT_COP') {
+                    return {};
+                }
                 if ( currentRole !== "impact-assessor" || (!impactassessment || !impactassessment.newAssessment)) {
                     return { style: {display: "none"} };
                 }
@@ -22,5 +28,5 @@ const BurgerMenu = assign(AnnotationsPlugin.BurgerMenu, {
 module.exports = {
     AnnotationsPlugin: assign(AnnotationsPlugin, {BurgerMenu}),
     reducers,
-    epics
+    epics: assign({}, epics, {getExternalAnnotations, saveExternalAnnotations, deleteExternalAnnotations, editExternalAnnotations})
 };

--- a/frontend/js/plugins/Annotations.jsx
+++ b/frontend/js/plugins/Annotations.jsx
@@ -7,8 +7,28 @@
  */
 const assign = require('object-assign');
 const {AnnotationsPlugin, epics, reducers} = require('../../MapStore2/web/client/plugins/Annotations');
+const {connect} = require('../../MapStore2/web/client/utils/PluginsUtils');
 
-const {getExternalAnnotations, saveExternalAnnotations, deleteExternalAnnotations, editExternalAnnotations} = require('../epics/emergencyManager');
+const {editAnnotation, removeAnnotation, cancelEditAnnotation,
+    saveAnnotation, toggleAdd, validationError, removeAnnotationGeometry, toggleStyle, setStyle, restoreStyle} =
+    require('../../MapStore2/web/client/actions/annotations');
+const {annotationsInfoSelector} = require('../../MapStore2/web/client/selectors/annotations');
+
+const AnnotationsInfoViewer = connect(annotationsInfoSelector,
+{
+    onEdit: editAnnotation,
+    onCancelEdit: cancelEditAnnotation,
+    onError: validationError,
+    onSave: saveAnnotation,
+    onRemove: removeAnnotation,
+    onAddGeometry: toggleAdd,
+    onStyleGeometry: toggleStyle,
+    onCancelStyle: restoreStyle,
+    onSaveStyle: toggleStyle,
+    onSetStyle: setStyle,
+    onDeleteGeometry: removeAnnotationGeometry
+})(require('../../MapStore2/web/client/components/mapcontrols/annotations/AnnotationsEditor'));
+
 const BurgerMenu = assign(AnnotationsPlugin.BurgerMenu, {
             selector: (state) => {
                 // For the moment annotations are available only for an impact-assessor editng an assessment
@@ -28,5 +48,5 @@ const BurgerMenu = assign(AnnotationsPlugin.BurgerMenu, {
 module.exports = {
     AnnotationsPlugin: assign(AnnotationsPlugin, {BurgerMenu}),
     reducers,
-    epics: assign({}, epics, {getExternalAnnotations, saveExternalAnnotations, deleteExternalAnnotations, editExternalAnnotations})
+    epics: assign({}, epics, require('../epics/emergencyManager')(AnnotationsInfoViewer))
 };

--- a/frontend/js/plugins/EmergencyManager.jsx
+++ b/frontend/js/plugins/EmergencyManager.jsx
@@ -13,6 +13,7 @@ const assign = require('object-assign');
 const {Accordion, Panel} = require('react-bootstrap');
 const Spinner = require('react-spinkit');
 const LocaleUtils = require('../../MapStore2/web/client/utils/LocaleUtils');
+const {setControlProperty} = require('../../MapStore2/web/client/actions/controls');
 
 const {loadRegions, selectRegions, toggleEntityValue, onSearchTextChange, resetAlertsTextSearch, toggleEntities,
     loadEvents, toggleEventVisibility} = require('../actions/alerts');
@@ -24,8 +25,9 @@ const {connect} = require('react-redux');
 const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 
 const EditCop = connect((state) => ({
-    hazards: state.alerts && state.alerts.hazards || []
-}), {cancelAddAssessment})(require('../components/EditCop'));
+    hazards: state.alerts && state.alerts.hazards || [],
+    currentHazard: state.impactassessment && state.impactassessment.currentHazard || {}
+}), {cancelAddAssessment, toggleAnnotations: setControlProperty.bind(null, 'annotations', 'enabled', true)})(require('../components/EditCop'));
 
 
 const TimeFilter = connect((state) => ({
@@ -111,7 +113,9 @@ class EmergencyManager extends React.Component {
         eventsLoading: false
     };
     renderList = () => {
+
         const {height} = this.props;
+
         const accordionHeight = height - (50 + 41 + 52 + 5 + 52 + 5 + 72);
         return (<div id="decat-impact-assessment" className="decat-accordion" >
             <Accordion defaultActiveKey="1">

--- a/frontend/static/decat/localConfig.json
+++ b/frontend/static/decat/localConfig.json
@@ -35,6 +35,10 @@
     "monitorState": [{"name": "routing", "path": "routing.location.pathname"}, {"name": "currentRole", "path": "security.currentRole"}],
     "initialState": {
       "defaultState": {
+        "impactassessment": {
+            "annotationRefreshTime": 5000,
+            "copValidationCheckRefreshTime": 60000
+        },
         "catalog":{
           "default": {
             "supportedFormats": [{"name": "csw", "label": "CSW"}],

--- a/frontend/static/decat/localConfig.json
+++ b/frontend/static/decat/localConfig.json
@@ -243,7 +243,7 @@
                     }
                 }
             },
-            "OmniBar", "BurgerMenu", "Expander", "Undo", "Redo", "ImpactAssessment","EarlyWarning", "EmergencyManager", "RightTOCPanel", "Save", "SaveAs", "CurrentIntervalFooter", {
+            "OmniBar", "BurgerMenu", "Expander", "Undo", "Redo", "ImpactAssessment","EarlyWarning", "EmergencyManager", "Notifications", "RightTOCPanel", "Save", "SaveAs", "CurrentIntervalFooter", {
             "name": "Annotations",
             "cfg": {
                 "width": 440,

--- a/frontend/static/decat/localConfig.json
+++ b/frontend/static/decat/localConfig.json
@@ -243,7 +243,7 @@
                     }
                 }
             },
-            "OmniBar", "BurgerMenu", "Expander", "Undo", "Redo", "ImpactAssessment","EarlyWarning", "RightTOCPanel", "Save", "SaveAs", "CurrentIntervalFooter", {
+            "OmniBar", "BurgerMenu", "Expander", "Undo", "Redo", "ImpactAssessment","EarlyWarning", "EmergencyManager", "RightTOCPanel", "Save", "SaveAs", "CurrentIntervalFooter", {
             "name": "Annotations",
             "cfg": {
                 "width": 440,

--- a/frontend/static/decat/translations/data.de-DE
+++ b/frontend/static/decat/translations/data.de-DE
@@ -1,6 +1,21 @@
 {
     "locale": "de-DE",
     "messages": {
-        "earlywarning": "Early Warning"
+        "earlywarning": "Early Warning",
+        "annotation": {
+            "external": "External annotations",
+            "externalError": "Could not get external annotations",
+            "save": "Save external annotation",
+            "saved": "Annotation saved correctly",
+            "saveError": "Could not save current annotation",
+            "delete": "Delete external annotation",
+            "deleted": "Annotation deleted correctly",
+            "deleteError": "Could not delete external annotation",
+            "edit": "Edit external annotation",
+            "edited": "Annotation edited correctly",
+            "editError": "Could not edit external annotation",
+            "notFound": "Annotation not found",
+            "createAgain": "Do you want create it again?"
+        }
     }
 }

--- a/frontend/static/decat/translations/data.en-US
+++ b/frontend/static/decat/translations/data.en-US
@@ -99,6 +99,21 @@
             "mapError": {
                 "error500": "Internal server error"
             }
+        },
+        "annotation": {
+            "external": "External annotations",
+            "externalError": "Could not get external annotations",
+            "save": "Save external annotation",
+            "saved": "Annotation saved correctly",
+            "saveError": "Could not save current annotation",
+            "delete": "Delete external annotation",
+            "deleted": "Annotation deleted correctly",
+            "deleteError": "Could not delete external annotation",
+            "edit": "Edit external annotation",
+            "edited": "Annotation edited correctly",
+            "editError": "Could not edit external annotation",
+            "notFound": "Annotation not found",
+            "createAgain": "Do you want create it again?"
         }
     }
 }

--- a/frontend/static/decat/translations/data.es-ES
+++ b/frontend/static/decat/translations/data.es-ES
@@ -2,6 +2,21 @@
 {
     "locale": "es-ES",
     "messages": {
-        "earlywarning": "Early Warning"
+        "earlywarning": "Early Warning",
+        "annotation": {
+            "external": "External annotations",
+            "externalError": "Could not get external annotations",
+            "save": "Save external annotation",
+            "saved": "Annotation saved correctly",
+            "saveError": "Could not save current annotation",
+            "delete": "Delete external annotation",
+            "deleted": "Annotation deleted correctly",
+            "deleteError": "Could not delete external annotation",
+            "edit": "Edit external annotation",
+            "edited": "Annotation edited correctly",
+            "editError": "Could not edit external annotation",
+            "notFound": "Annotation not found",
+            "createAgain": "Do you want create it again?"
+        }
     }
 }

--- a/frontend/static/decat/translations/data.fr-FR
+++ b/frontend/static/decat/translations/data.fr-FR
@@ -2,6 +2,21 @@
 {
     "locale": "fr-FR",
     "messages": {
-        "earlywarning": "Early Warning"
+        "earlywarning": "Early Warning",
+        "annotation": {
+            "external": "External annotations",
+            "externalError": "Could not get external annotations",
+            "save": "Save external annotation",
+            "saved": "Annotation saved correctly",
+            "saveError": "Could not save current annotation",
+            "delete": "Delete external annotation",
+            "deleted": "Annotation deleted correctly",
+            "deleteError": "Could not delete external annotation",
+            "edit": "Edit external annotation",
+            "edited": "Annotation edited correctly",
+            "editError": "Could not edit external annotation",
+            "notFound": "Annotation not found",
+            "createAgain": "Do you want create it again?"
+        }
     }
 }

--- a/frontend/static/decat/translations/data.it-IT
+++ b/frontend/static/decat/translations/data.it-IT
@@ -100,6 +100,21 @@
             "mapError": {
                 "error500": "Errore interno del server"
             }
+        },
+        "annotation": {
+            "external": "Annotazioni esterne",
+            "externalError": "Le annotazioni esterne non sono state caricate correttamente",
+            "save": "Salva annotazione esterna",
+            "saved": "Annotazione salvata correttamente",
+            "saveError": "L'annotazione non è stata salvata correttamente",
+            "delete": "Elimina annotazione",
+            "deleted": "Annotazione eliminata correttamente",
+            "deleteError": "L'annotazione non è stata eliminata correttamente",
+            "edit": "Modifica annotazione",
+            "edited": "Annotazione modificata correttamente",
+            "editError": "L'annotazione non è stata modificata correttamente",
+            "notFound": "Annotazione non trovata",
+            "createAgain": "Vuoi creare nuovamante l'annotazione?"
         }
     }
 }


### PR DESCRIPTION
- Save, load and edit of external annotations for impact assessor and emergency manager
- Refresh to new COP if another is promoted (Emergency manager)
- Added refresh time in intialState (localConfig.json)

```
"initialState": {
      "defaultState": {
        "impactassessment": {
            "annotationRefreshTime": 5000,
            "copValidationCheckRefreshTime": 60000
        },
        ....
```